### PR TITLE
fix: live preview bundler module resolution [SPA-4097]

### DIFF
--- a/core/services/contentful-angular.service.spec.ts
+++ b/core/services/contentful-angular.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { ContentfulLivePreview, ContentfulLivePreviewInitConfig, LivePreviewProps } from '@contentful/live-preview';
-import { InspectorModeDataAttributes, InspectorModeTags } from '@contentful/live-preview/dist/inspectorMode/types';
+import { ContentfulLivePreview, ContentfulLivePreviewInitConfig, LivePreviewProps, InspectorModeDataAttributes, type InspectorModeTags } from '@contentful/live-preview';
 
 import { ContentfulAngularService } from './contentful-angular.service';
 

--- a/core/services/contentful-angular.service.ts
+++ b/core/services/contentful-angular.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ContentfulLivePreview, ContentfulLivePreviewInitConfig, LivePreviewProps } from '@contentful/live-preview';
-import { Argument, SubscribeCallback } from '@contentful/live-preview/dist/types';
+import { ContentfulLivePreview, ContentfulLivePreviewInitConfig, LivePreviewProps, type Argument, type SubscribeCallback } from '@contentful/live-preview';
 
 interface Options {
   locale?: string;

--- a/core/services/contentful-live-preview.service.spec.ts
+++ b/core/services/contentful-live-preview.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgZone, Renderer2, RendererFactory2 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { InspectorModeDataAttributes } from '@contentful/live-preview/dist/inspectorMode/types';
+import { InspectorModeDataAttributes } from '@contentful/live-preview';
 import { Store, StoreModule } from '@ngrx/store';
 
 import { CmsActions, ContentSlotComponentData, ConverterService, LanguageService, PageContext, RoutingService } from '@spartacus/core';

--- a/core/services/contentful-live-preview.service.ts
+++ b/core/services/contentful-live-preview.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, NgZone, Renderer2 } from '@angular/core';
-import { InspectorModeDataAttributes, InspectorModeEntryTags } from '@contentful/live-preview/dist/inspectorMode/types';
-import { Argument } from '@contentful/live-preview/dist/types';
+import { InspectorModeDataAttributes, type InspectorModeEntryTags, type Argument } from '@contentful/live-preview';
 import { Store } from '@ngrx/store';
 
 import {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "tslib": "^2.8.0"
   },
   "peerDependencies": {
-    "@angular-devkit/schematics": "^19.2.15",
-    "@angular/common": "^19.2.15",
-    "@angular/core": "^19.2.15",
+    "@angular-devkit/schematics": "^19.2.15 || ^20.0.0 || ^21.0.0",
+    "@angular/common": "^19.2.15 || ^20.0.0 || ^21.0.0",
+    "@angular/core": "^19.2.15 || ^20.0.0 || ^21.0.0",
     "@spartacus/core": "~221121.5.0",
     "@spartacus/schematics": "~221121.5.0",
     "rxjs": "^7.8.0"


### PR DESCRIPTION
Don't do deep imports to unblock Angular v21 (which uses `bundle` moduleResolution).